### PR TITLE
add settingtypes.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 This is a framework for registering and generating loot. It also adds loot
 chests to dungeons.
 
-Config
+Settings
 ======
 ```loot_vaults``` - Set to ```true``` to enable loot vault generation. <br/>
-```no_dungeon_loot``` - Set to ```true``` to disable loot generation in dungeons.
+```loot_dungeons``` - Set to ```true``` to enable loot generation in dungeons.
 
 API
 ===

--- a/init.lua
+++ b/init.lua
@@ -67,11 +67,12 @@ end
 loot.modpath = modpath
 
 local vaults = minetest.setting_getbool("loot_vaults")
-local no_d_loot = minetest.setting_getbool("no_dungeon_loot")
+local dungeon_loot = minetest.setting_getbool("loot_dungeons")
+if dungeon_loot == nil then dungeon_loot = true end -- default dungeon loot to true
 
 dofile(modpath .. "default_loot.lua")
 
 dofile(modpath .. "loot_node.lua")
 if vaults then dofile(modpath .. "loot_vault.lua") end
-if not no_d_loot then dofile(modpath .. "dungeon.lua") end
+if dungeon_loot then dofile(modpath .. "dungeon.lua") end
 

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,5 @@
+#Generate loot vaults
+loot_vaults (Generate loot vaults) bool false
+
+#Add loot to dungeons
+loot_dungeons (Add loot to dungeons) bool true


### PR DESCRIPTION
This puts the settings for this mod into the in-game "advanced settings" screen.

Note that I've swapped "no dungeon loot" for "dungeon loot" and set the default to "true", since otherwise there'd be a confusing double negative ("no dungeon loot enabled"/"no dungeon loot disabled")