### PR TITLE
change to add_node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+nohup.out

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-nohup.out

--- a/dungeon.lua
+++ b/dungeon.lua
@@ -13,7 +13,7 @@ minetest.register_on_generated(function(minp, maxp, blockseed)
 
 		for i, location in ipairs(locations) do
 			if math.random(3) == 1 then
-				minetest.place_node(location, { name = "loot:loot_node" })
+				minetest.add_node(location, { name = "loot:loot_node" })
 			end
 		end
 end)

--- a/loot_node.lua
+++ b/loot_node.lua
@@ -14,7 +14,7 @@ minetest.register_abm({
 	chance = 1,
 	action = function(pos)
 		minetest.remove_node(pos)
-		minetest.place_node(pos, {name = "default:chest"})
+		minetest.add_node(pos, {name = "default:chest"})
 		local inv = minetest.get_meta(pos):get_inventory()
 
 		local valuable_count = math.random(1,3)


### PR DESCRIPTION
place_node requires param2 normally ([for nodes that need facedir](https://forum.minetest.net/viewtopic.php?f=47&t=17650)?), but param2 has not been specified. set_node is normally used for spawning. place_node mimics player placing behavior, so add_node (alias of set_node) seems more appropriate for generated structures (unless someone wants to check for walls and determine a facedir and use that [0 to 3] for param2). See also:
* https://forum.minetest.net/viewtopic.php?f=47&t=17650 "Problems solved. I should be using: `minetest.set_node`"
* minetest_game/mods/farming/api.lua
* minetest_game/mods/dungeon_loot/mapgen.lua
